### PR TITLE
Gate hover sounds on real pointer movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ import { play, bind, setEnabled, sounds, type SoundName } from "cuelume";
 
 - **Pointer-aware.** Hover, press, and release require a fine mouse pointer. Toggle follows native click activation, including keyboard and touch.
 - **Hover repeat guard.** Hover sounds are globally throttled to one every 150ms, so sweeping across a menu stays quiet.
+- **No phantom hovers.** After a mouse press or a scroll, hover stays disarmed until the pointer genuinely moves — SPA navigations and scrolling that swap the DOM under a stationary cursor don't chirp.
 - **One lazy `AudioContext`.** Shared across all sounds, created on first use.
 - **Autoplay-friendly.** Attempts to resume suspended audio without surfacing errors when a browser blocks it.
 - **SSR-safe.** Importing on the server is a no-op.

--- a/src/interactions/bind.ts
+++ b/src/interactions/bind.ts
@@ -15,10 +15,35 @@ import { play } from "../audio/engine.js";
 import { isSoundName, type SoundName } from "../sounds/recipes.js";
 
 const HOVER_GAP_MS = 150;
+const HOVER_REARM_DISTANCE_PX = 4;
 const boundRoots = new WeakSet<ParentNode>();
 const handledEvents = new WeakSet<Event>();
 
 let lastHoverTime = -Infinity;
+
+// Browsers re-dispatch pointerenter when the DOM changes under a stationary
+// cursor — an SPA navigation or a scroll can land a hover target beneath the
+// pointer and chirp without any real mouse movement. Genuine hovers are always
+// accompanied by pointermove, which is never synthesized, so after a click or
+// scroll the hover channel stays disarmed until the pointer travels a few
+// pixels (enough to ignore hand jitter during a click).
+let hoverArmed = true;
+let armX = 0;
+let armY = 0;
+let pointerX = 0;
+let pointerY = 0;
+
+function disarmHover(): void {
+  hoverArmed = false;
+  armX = pointerX;
+  armY = pointerY;
+}
+
+function trackPointer(event: Event): void {
+  const pointer = event as PointerEvent;
+  pointerX = pointer.clientX;
+  pointerY = pointer.clientY;
+}
 
 function resolve(el: HTMLElement, attr: string, fallback: SoundName): SoundName {
   const requested = el.getAttribute(attr);
@@ -47,11 +72,18 @@ function listen(
   (root as EventTarget).addEventListener(
     eventName,
     (event) => {
+      if (eventName === "pointerdown" && (event as PointerEvent).pointerType === "mouse") {
+        trackPointer(event);
+        disarmHover();
+      }
+
       const element = findTarget(root, event, attr);
       if (!element || handledEvents.has(event)) return;
       if (mouseOnly && !isMouse(event as PointerEvent)) return;
 
       if (eventName === "pointerenter") {
+        if (!hoverArmed) return;
+
         const relatedTarget = (event as PointerEvent).relatedTarget;
         if (relatedTarget instanceof Node && element.contains(relatedTarget)) return;
 
@@ -81,4 +113,20 @@ export function bind(root?: ParentNode): void {
   listen(scope, "pointerdown", "data-cuelume-press", "press");
   listen(scope, "pointerup", "data-cuelume-release", "release");
   listen(scope, "click", "data-cuelume-toggle", "toggle");
+
+  const target = scope as EventTarget;
+  target.addEventListener(
+    "pointermove",
+    (event) => {
+      trackPointer(event);
+      if (
+        !hoverArmed &&
+        Math.hypot(pointerX - armX, pointerY - armY) > HOVER_REARM_DISTANCE_PX
+      ) {
+        hoverArmed = true;
+      }
+    },
+    true,
+  );
+  target.addEventListener("scroll", disarmHover, true);
 }

--- a/test/runtime.test.mjs
+++ b/test/runtime.test.mjs
@@ -265,6 +265,33 @@ test("binding is delegated, dynamic, idempotent, and globally throttled", async 
   root.emit("pointerenter", child, { relatedTarget: later });
   assert.equal(counts.buffers, 5);
 
+  // A mouse click disarms hover: the pointerenter that browsers re-dispatch
+  // when an SPA navigation swaps the DOM under the stationary cursor stays
+  // quiet, no matter how long the transition takes.
+  now += 151;
+  root.emit("pointerdown", later, { clientX: 10, clientY: 10 });
+  now += 10_000;
+  root.emit("pointerenter", later);
+  assert.equal(counts.buffers, 5);
+
+  // Hand jitter within the re-arm distance stays quiet too.
+  root.emit("pointermove", root, { clientX: 12, clientY: 11 });
+  root.emit("pointerenter", later);
+  assert.equal(counts.buffers, 5);
+
+  // Real movement re-arms instantly.
+  root.emit("pointermove", root, { clientX: 30, clientY: 30 });
+  now += 151;
+  root.emit("pointerenter", later);
+  assert.equal(counts.buffers, 6);
+
+  // Touch presses don't disarm the (mouse-only) hover channel.
+  root.emit("pointerdown", touchTarget, { pointerType: "touch" });
+  assert.equal(counts.buffers, 7);
+  now += 151;
+  root.emit("pointerenter", later);
+  assert.equal(counts.buffers, 8);
+
 });
 
 test("finished shimmer graphs disconnect after their audible tail", async (context) => {


### PR DESCRIPTION
Fixes #7 — implements Option B (movement gating) from the issue.

Browsers re-dispatch `pointerenter` when the DOM changes under a stationary cursor, so an SPA navigation (or a scroll) could land a `data-cuelume-hover` target beneath the pointer and chirp with zero mouse movement — a phantom hover stacked on top of the click.

Genuine hovers are always accompanied by `pointermove`, which browsers never synthesize. So after a mouse `pointerdown` or a `scroll`, the hover channel stays disarmed until the pointer travels more than 4px from where it was disarmed (which also ignores hand jitter during a click). Touch presses don't disarm the (mouse-only) hover channel.

Notes:

- No new `pointerdown` listener — the gating is folded into the existing one, so `bind()`'s listener-count behavior (and the idempotency guarantees) are unchanged. `pointermove` and `scroll` gain one delegated listener each.
- Covered by four new assertions at the end of the binding test: the re-dispatched `pointerenter` stays quiet no matter how long the navigation takes, sub-threshold jitter stays quiet, real movement re-arms instantly, and touch presses don't disarm.
- README gains a "No phantom hovers" bullet under "Defaults that behave".

We've been running this guard in production (React Router SSR app) and verified in-browser that SPA-navigation re-dispatches are fully suppressed while normal hovers are unaffected.
