### PR TITLE
Add per-play transpose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ import { play } from "cuelume";
 
 await navigator.clipboard.writeText(text);
 play("success");
+
+// Shift pitched layers down one octave (noise layers are unchanged).
+play("chime", { transpose: -12 });
 ```
 
 Need a sound preference? Your app owns the setting; Cuelume only applies it:
@@ -85,10 +88,10 @@ Cuelume starts enabled and does not read or write storage.
 ## API
 
 ```ts
-import { play, bind, setEnabled, sounds, type SoundName } from "cuelume";
+import { play, bind, setEnabled, sounds, type PlayOptions, type SoundName } from "cuelume";
 ```
 
-- **`play(name?: SoundName)`** — play a sound immediately. Defaults to `"chime"`.
+- **`play(name?: SoundName, options?: PlayOptions)`** — play a sound immediately. Defaults to `"chime"`.
 - **`bind(root?: ParentNode)`** — delegate all `data-cuelume-*` interactions under `root` (defaults to the whole document). Idempotent and handles elements added later.
 - **`setEnabled(enabled: boolean)`** — enable or disable future playback. Does not persist the preference or stop sounds already playing.
 - **`sounds`** — the list of all sound names.

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -19,16 +19,22 @@ const SOURCE_STOP_PADDING = 0.05;
 const CLEANUP_MARGIN = 0.05;
 const INAUDIBLE_GAIN = 0.001;
 
+export type PlayOptions = {
+  /** Shifts pitched layers by this many semitones. Noise layers are unaffected. */
+  transpose?: number;
+};
+
 function renderTone(
   context: AudioContext,
   destination: AudioNode,
   layer: ToneLayer,
   startTime: number,
+  transposeCents: number,
 ): void {
   const oscillator = context.createOscillator();
   oscillator.type = layer.waveform;
   oscillator.frequency.setValueAtTime(layer.frequency, startTime);
-  if (layer.detune) oscillator.detune.value = layer.detune;
+  oscillator.detune.value = (layer.detune ?? 0) + transposeCents;
 
   if (layer.glideTo !== undefined) {
     const glideTime = layer.glideTime ?? layer.attack + layer.decay;
@@ -120,7 +126,7 @@ function shimmerTail(shimmer?: Shimmer): number {
   return shimmer.delay * (1 + Math.ceil(Math.log(INAUDIBLE_GAIN) / Math.log(shimmer.feedback)));
 }
 
-function renderRecipe(context: AudioContext, recipe: SoundRecipe): void {
+function renderRecipe(context: AudioContext, recipe: SoundRecipe, transposeCents: number): void {
   const now = context.currentTime;
   const master = context.createGain();
   master.gain.value = recipe.masterGain;
@@ -132,7 +138,7 @@ function renderRecipe(context: AudioContext, recipe: SoundRecipe): void {
 
   for (const layer of recipe.layers) {
     const startTime = now + (layer.offset ?? 0);
-    if (layer.kind === "tone") renderTone(context, master, layer, startTime);
+    if (layer.kind === "tone") renderTone(context, master, layer, startTime, transposeCents);
     else renderNoise(context, master, layer, startTime);
   }
 
@@ -172,21 +178,27 @@ function getAudioContext(): AudioContext | null {
  * started it suspended (e.g. before any user gesture), and is a no-op
  * when Web Audio is unavailable (SSR, old browsers).
  */
-export function play(sound: SoundName = "chime"): void {
+export function play(sound: SoundName = "chime", options?: PlayOptions): void {
   if (!enabled || !isSoundName(sound)) return;
   if (typeof navigator !== "undefined" && navigator.userActivation?.hasBeenActive === false) return;
+
+  const transpose = options?.transpose;
+  const transposeCents = typeof transpose === "number" ? transpose * 100 : 0;
+  const safeTransposeCents = Number.isFinite(transposeCents) ? transposeCents : 0;
 
   const context = getAudioContext();
   if (!context) return;
 
   const recipe = RECIPES[sound];
   if (context.state === "running") {
-    renderRecipe(context, recipe);
+    renderRecipe(context, recipe, safeTransposeCents);
   } else {
     try {
       void context.resume().then(
         () => {
-          if (enabled && context.state === "running") renderRecipe(context, recipe);
+          if (enabled && context.state === "running") {
+            renderRecipe(context, recipe, safeTransposeCents);
+          }
         },
         () => {},
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 export type { SoundName } from "./sounds/recipes.js";
+export type { PlayOptions } from "./audio/engine.js";
 export { sounds } from "./sounds/recipes.js";
 export { play, setEnabled } from "./audio/engine.js";
 export { bind } from "./interactions/bind.js";

--- a/test/runtime.test.mjs
+++ b/test/runtime.test.mjs
@@ -113,6 +113,63 @@ test("invalid names and AudioContext failures are silent", async (context) => {
 
 });
 
+test("play transposes pitched layers in semitones", async (context) => {
+  context.after(restoreGlobals);
+  const detunes = [];
+
+  class AudioNodeStub {
+    connect(destination) {
+      return destination;
+    }
+    disconnect() {}
+  }
+
+  const parameter = () => ({
+    value: 0,
+    setValueAtTime() {},
+    exponentialRampToValueAtTime() {},
+  });
+
+  class TransposeContext {
+    state = "running";
+    currentTime = 0;
+    sampleRate = 1;
+    destination = new AudioNodeStub();
+    createGain() {
+      return Object.assign(new AudioNodeStub(), { gain: parameter() });
+    }
+    createOscillator() {
+      const detune = parameter();
+      detunes.push(detune);
+      return Object.assign(new AudioNodeStub(), {
+        frequency: parameter(),
+        detune,
+        start() {},
+        stop() {},
+      });
+    }
+    createBiquadFilter() {
+      return Object.assign(new AudioNodeStub(), { frequency: parameter(), Q: parameter() });
+    }
+    createDelay() {
+      return Object.assign(new AudioNodeStub(), { delayTime: parameter() });
+    }
+  }
+
+  setGlobal("setTimeout", () => 0);
+  setGlobal("window", { AudioContext: TransposeContext });
+
+  const { play } = await import(`../dist/audio/engine.js?transpose=${Date.now()}`);
+  play("chime", { transpose: -12 });
+  play("bloom", { transpose: 1 });
+  play("chime", { transpose: Number.NaN });
+
+  assert.deepEqual(
+    detunes.map(({ value }) => value),
+    [-1200, -1200, 100, 112, 0, 0],
+  );
+});
+
 test("binding is delegated, dynamic, idempotent, and globally throttled", async (context) => {
   context.after(restoreGlobals);
   const counts = { buffers: 0, oscillators: 0 };


### PR DESCRIPTION
Adds an optional semitone transpose to imperative playback:

```js
play("chime", { transpose: -12 });
```

**Scope:**
  - Add PlayOptions with transpose?: number.
  - Convert semitones to cents and apply them through OscillatorNode.detune.
  - Preserve each recipe layer’s existing detuning.
  - Leave noise layers unchanged.
  - Export PlayOptions.
  - Add one focused runtime test and a short README example.

**Out of scope:**
  - Declarative data-cuelume-* transposition.
  - Global transposition settings.
  - Transposing noise filters.
  - Volume, tempo, or playback-speed options.
  - Build or packaging changes.

**Acceptance criteria:**
  - Existing play("chime") calls behave identically.
  - play("chime", { transpose: -12 }) plays one octave lower.
  - Built-in layer detuning remains additive.
  - Invalid/non-finite transpose values fall back to zero.
  - Build and tests pass.