### PR TITLE
Fix silent first playback for short cues

### DIFF
--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -19,13 +19,15 @@ const SOURCE_STOP_PADDING = 0.05;
 const CLEANUP_MARGIN = 0.05;
 const INAUDIBLE_GAIN = 0.001;
 const OUTPUT_GAIN = 4;
+const PLAYBACK_LEAD_SECONDS = 0.01;
+const PRIMER_DURATION_SECONDS = 0.02;
 
 function renderTone(
   context: AudioContext,
   destination: AudioNode,
   layer: ToneLayer,
   startTime: number,
-): void {
+): OscillatorNode {
   const oscillator = context.createOscillator();
   oscillator.type = layer.waveform;
   oscillator.frequency.setValueAtTime(layer.frequency, startTime);
@@ -44,6 +46,7 @@ function renderTone(
   oscillator.connect(gain).connect(destination);
   oscillator.start(startTime);
   oscillator.stop(startTime + layer.attack + layer.decay + SOURCE_STOP_PADDING);
+  return oscillator;
 }
 
 function renderNoise(
@@ -51,7 +54,7 @@ function renderNoise(
   destination: AudioNode,
   layer: NoiseLayer,
   startTime: number,
-): void {
+): AudioBufferSourceNode {
   const duration = layer.attack + layer.decay + SOURCE_STOP_PADDING;
   const length = Math.max(1, Math.floor(duration * context.sampleRate));
   const buffer = context.createBuffer(1, length, context.sampleRate);
@@ -73,7 +76,7 @@ function renderNoise(
 
   source.connect(filter).connect(gain).connect(destination);
   source.start(startTime);
-  source.stop(startTime + duration);
+  return source;
 }
 
 /** Wires a soft echo/shimmer send off `source`, feeding back into `destination`. */
@@ -106,14 +109,6 @@ function attachShimmer(
   return [delay, feedbackFilter, feedbackGain, wetGain];
 }
 
-function sourceEnd(recipe: SoundRecipe): number {
-  return Math.max(
-    ...recipe.layers.map(
-      (layer) => (layer.offset ?? 0) + layer.attack + layer.decay + SOURCE_STOP_PADDING,
-    ),
-  );
-}
-
 function shimmerTail(shimmer?: Shimmer): number {
   if (!shimmer || shimmer.feedback <= 0) return 0;
   if (shimmer.feedback >= 1) return shimmer.delay;
@@ -142,7 +137,6 @@ function getOutput(context: AudioContext): GainNode {
 }
 
 function renderRecipe(context: AudioContext, recipe: SoundRecipe, volume: number): void {
-  const now = context.currentTime;
   const output = getOutput(context);
   const master = context.createGain();
   master.gain.value = recipe.masterGain * volume;
@@ -151,23 +145,71 @@ function renderRecipe(context: AudioContext, recipe: SoundRecipe, volume: number
   const shimmerNodes = recipe.shimmer
     ? attachShimmer(context, master, output, recipe.shimmer)
     : [];
+  const recipeStartTime = context.currentTime + PLAYBACK_LEAD_SECONDS;
+  const sources: AudioScheduledSourceNode[] = [];
 
   for (const layer of recipe.layers) {
-    const startTime = now + (layer.offset ?? 0);
-    if (layer.kind === "tone") renderTone(context, master, layer, startTime);
-    else renderNoise(context, master, layer, startTime);
+    const startTime = recipeStartTime + (layer.offset ?? 0);
+    if (layer.kind === "tone") sources.push(renderTone(context, master, layer, startTime));
+    else sources.push(renderNoise(context, master, layer, startTime));
   }
 
-  const cleanupAfterMs = (sourceEnd(recipe) + shimmerTail(recipe.shimmer) + CLEANUP_MARGIN) * 1000;
-  setTimeout(() => {
-    master.disconnect();
-    for (const node of shimmerNodes) node.disconnect();
-  }, cleanupAfterMs);
+  let remainingSources = sources.length;
+  for (const source of sources) {
+    source.onended = () => {
+      remainingSources--;
+      if (remainingSources > 0) return;
+
+      // Anchor cleanup to rendered source completion so a cold output path
+      // cannot be disconnected by a wall timer before playback begins.
+      const cleanupAfterMs = (shimmerTail(recipe.shimmer) + CLEANUP_MARGIN) * 1000;
+      setTimeout(() => {
+        master.disconnect();
+        for (const node of shimmerNodes) node.disconnect();
+      }, cleanupAfterMs);
+    };
+  }
 }
 
 let sharedContext: AudioContext | null = null;
 let enabled = true;
 let globalVolume = 1;
+let rendererReady = false;
+let rendererPriming = false;
+let pendingPlayback: Array<{
+  context: AudioContext;
+  recipe: SoundRecipe;
+  volume: number;
+}> = [];
+
+function renderAfterPriming(context: AudioContext, recipe: SoundRecipe, volume: number): void {
+  if (rendererReady) {
+    renderRecipe(context, recipe, volume);
+    return;
+  }
+
+  pendingPlayback.push({ context, recipe, volume });
+  if (rendererPriming) return;
+  rendererPriming = true;
+
+  // A new context can report `running` before its output renderer consumes
+  // source commands. This silent buffer's ended event proves rendering began.
+  const primer = context.createBufferSource();
+  const primerLength = Math.max(1, Math.ceil(context.sampleRate * PRIMER_DURATION_SECONDS));
+  primer.buffer = context.createBuffer(1, primerLength, context.sampleRate);
+  primer.connect(getOutput(context));
+  primer.onended = () => {
+    rendererReady = true;
+    rendererPriming = false;
+    const queuedPlayback = pendingPlayback;
+    pendingPlayback = [];
+    if (!enabled) return;
+    for (const queued of queuedPlayback) {
+      renderRecipe(queued.context, queued.recipe, queued.volume);
+    }
+  };
+  primer.start();
+}
 
 function normalizeVolume(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value)
@@ -218,12 +260,14 @@ export function play(sound: SoundName = "chime", options?: { volume?: number }):
 
   const recipe = RECIPES[sound];
   if (context.state === "running") {
-    renderRecipe(context, recipe, playVolume);
+    renderAfterPriming(context, recipe, playVolume);
   } else {
     try {
       void context.resume().then(
         () => {
-          if (enabled && context.state === "running") renderRecipe(context, recipe, playVolume);
+          if (enabled && context.state === "running") {
+            renderAfterPriming(context, recipe, playVolume);
+          }
         },
         () => {},
       );

--- a/test/runtime.test.mjs
+++ b/test/runtime.test.mjs
@@ -135,6 +135,7 @@ test("volume is clamped and one boosted output bus is reused", async (context) =
   context.after(restoreGlobals);
   const gains = [];
   const compressors = [];
+  const bufferSources = [];
 
   class AudioNodeStub {
     constructor(name) {
@@ -167,11 +168,13 @@ test("volume is clamped and one boosted output bus is reused", async (context) =
       return { getChannelData: () => new Float32Array(1) };
     }
     createBufferSource() {
-      return Object.assign(new AudioNodeStub("buffer-source"), {
+      const source = Object.assign(new AudioNodeStub("buffer-source"), {
         buffer: null,
         start() {},
         stop() {},
       });
+      bufferSources.push(source);
+      return source;
     }
     createBiquadFilter() {
       return Object.assign(new AudioNodeStub("filter"), {
@@ -188,6 +191,7 @@ test("volume is clamped and one boosted output bus is reused", async (context) =
 
   setVolume(2);
   play("press", { volume: 0.5 });
+  bufferSources[0].onended();
   setVolume(0.5);
   play("press", { volume: 0.5 });
   play("press", { volume: 2 });
@@ -209,6 +213,97 @@ test("volume is clamped and one boosted output bus is reused", async (context) =
   assert.deepEqual(output.connections, [compressors[0]]);
   assert.equal(compressors[0].connections.length, 1);
   assert.equal(compressors[0].connections[0].name, "destination");
+});
+
+test("the renderer is primed before short cues are scheduled", async (context) => {
+  context.after(restoreGlobals);
+  const sourceStarts = [];
+  const sourceStops = [];
+  const sources = [];
+  const buffers = [];
+  const envelopeEvents = [];
+  const timers = [];
+
+  class AudioNodeStub {
+    connect(destination) {
+      return destination;
+    }
+    disconnect() {}
+  }
+
+  let gainCount = 0;
+  class SchedulingContext {
+    state = "running";
+    currentTime = 7;
+    sampleRate = 48_000;
+    destination = new AudioNodeStub();
+    createGain() {
+      gainCount++;
+      const recordsEnvelope = gainCount === 3;
+      return Object.assign(new AudioNodeStub(), {
+        gain: {
+          value: 0,
+          setValueAtTime(value, time) {
+            if (recordsEnvelope) envelopeEvents.push(["set", value, time]);
+          },
+          exponentialRampToValueAtTime(value, time) {
+            if (recordsEnvelope) envelopeEvents.push(["ramp", value, time]);
+          },
+        },
+      });
+    }
+    createDynamicsCompressor() {
+      return compressor(new AudioNodeStub());
+    }
+    createBuffer(channels, length, sampleRate) {
+      buffers.push([channels, length, sampleRate]);
+      return { getChannelData: () => new Float32Array(length) };
+    }
+    createBufferSource() {
+      const source = Object.assign(new AudioNodeStub(), {
+        buffer: null,
+        start(time) {
+          sourceStarts.push(time);
+        },
+        stop(time) {
+          sourceStops.push(time);
+        },
+      });
+      sources.push(source);
+      return source;
+    }
+    createBiquadFilter() {
+      return Object.assign(new AudioNodeStub(), {
+        frequency: audioParam(),
+        Q: audioParam(),
+      });
+    }
+  }
+
+  setGlobal("setTimeout", (callback, delay) => {
+    timers.push({ callback, delay });
+    return 0;
+  });
+  setGlobal("window", { AudioContext: SchedulingContext });
+
+  const { play } = await import(`../dist/audio/engine.js?scheduling=${Date.now()}`);
+  play("press");
+
+  assert.deepEqual(sourceStarts, [undefined]);
+  assert.deepEqual(buffers, [[1, 960, 48_000]]);
+  assert.equal(envelopeEvents.length, 0);
+  sources[0].onended();
+  assert.deepEqual(sourceStarts, [undefined, 7.01]);
+  assert.deepEqual(buffers[1], [1, 3_408, 48_000]);
+  assert.deepEqual(sourceStops, []);
+  assert.deepEqual(envelopeEvents, [
+    ["set", 0.0001, 7.01],
+    ["ramp", 0.13, 7.011],
+    ["ramp", 0.0001, 7.031],
+  ]);
+  assert.equal(timers.length, 0);
+  sources[1].onended();
+  assert.equal(Math.round(timers[0].delay), 50);
 });
 
 test("binding is delegated, dynamic, idempotent, and globally throttled", async (context) => {
@@ -248,7 +343,13 @@ test("binding is delegated, dynamic, idempotent, and globally throttled", async 
       return { getChannelData: () => new Float32Array(1) };
     }
     createBufferSource() {
-      return Object.assign(new AudioNodeStub(), { buffer: null, start() {}, stop() {} });
+      return Object.assign(new AudioNodeStub(), {
+        buffer: null,
+        start() {
+          this.onended?.();
+        },
+        stop() {},
+      });
     }
     createBiquadFilter() {
       return Object.assign(new AudioNodeStub(), { frequency: audioParam(), Q: audioParam() });
@@ -323,31 +424,31 @@ test("binding is delegated, dynamic, idempotent, and globally throttled", async 
   const first = new FakeElement(root);
   first.setAttribute("data-cuelume-hover", "whisper");
   root.emit("pointerenter", first);
-  assert.equal(counts.buffers, 1);
+  assert.equal(counts.buffers, 2);
 
   const later = new FakeElement(root);
   later.setAttribute("data-cuelume-hover", "whisper");
   now += 100;
   root.emit("pointerenter", later);
-  assert.equal(counts.buffers, 1);
+  assert.equal(counts.buffers, 2);
 
   now += 51;
   root.emit("pointerenter", later);
-  assert.equal(counts.buffers, 2);
+  assert.equal(counts.buffers, 3);
 
   later.setAttribute("data-cuelume-toggle", "whisper");
   root.emit("click", later, { pointerType: undefined });
-  assert.equal(counts.buffers, 3);
+  assert.equal(counts.buffers, 4);
   later.removeAttribute("data-cuelume-toggle");
   root.emit("click", later, { pointerType: undefined });
-  assert.equal(counts.buffers, 3);
+  assert.equal(counts.buffers, 4);
 
   const touchTarget = new FakeElement(root);
   touchTarget.setAttribute("data-cuelume-press", "whisper");
   touchTarget.setAttribute("data-cuelume-release", "whisper");
   root.emit("pointerdown", touchTarget, { pointerType: "touch" });
   root.emit("pointerup", touchTarget, { pointerType: "touch" });
-  assert.equal(counts.buffers, 5);
+  assert.equal(counts.buffers, 6);
 
   const invalid = new FakeElement(root);
   invalid.setAttribute("data-cuelume-hover", "toString");
@@ -359,7 +460,7 @@ test("binding is delegated, dynamic, idempotent, and globally throttled", async 
   const child = new FakeElement(later);
   now += 151;
   root.emit("pointerenter", child, { relatedTarget: later });
-  assert.equal(counts.buffers, 5);
+  assert.equal(counts.buffers, 6);
 
 });
 
@@ -368,6 +469,7 @@ test("finished shimmer graphs disconnect after their audible tail", async (conte
   const timers = [];
   const disconnected = [];
   const nodes = new Map();
+  const sources = [];
 
   class AudioNodeStub {
     constructor(name) {
@@ -406,13 +508,26 @@ test("finished shimmer graphs disconnect after their audible tail", async (conte
         Q: audioParam(),
       });
     }
+    createBuffer() {
+      return { getChannelData: () => new Float32Array(1) };
+    }
+    createBufferSource() {
+      return Object.assign(new AudioNodeStub("primer"), {
+        buffer: null,
+        start() {
+          this.onended?.();
+        },
+      });
+    }
     createOscillator() {
-      return Object.assign(new AudioNodeStub("oscillator"), {
+      const source = Object.assign(new AudioNodeStub("oscillator"), {
         frequency: audioParam(),
         detune: audioParam(),
         start() {},
         stop() {},
       });
+      sources.push(source);
+      return source;
     }
   }
 
@@ -425,8 +540,12 @@ test("finished shimmer graphs disconnect after their audible tail", async (conte
   const { play } = await import(`../dist/audio/engine.js?cleanup=${Date.now()}`);
   play("chime");
 
+  assert.equal(timers.length, 0);
+  sources[0].onended();
+  assert.equal(timers.length, 0);
+  sources[1].onended();
   assert.equal(timers.length, 1);
-  assert.equal(Math.round(timers[0].delay), 1176);
+  assert.equal(Math.round(timers[0].delay), 770);
   assert.equal(nodes.get("master").connections.includes(nodes.get("output")), true);
   assert.equal(nodes.get("wet-gain").connections.includes(nodes.get("output")), true);
   assert.deepEqual(nodes.get("output").connections, [nodes.get("limiter")]);
@@ -435,5 +554,5 @@ test("finished shimmer graphs disconnect after their audible tail", async (conte
   assert.deepEqual(disconnected, ["master", "delay", "feedback-filter", "feedback-gain", "wet-gain"]);
 
   play("chime");
-  assert.equal(timers.length, 2);
+  assert.equal(timers.length, 1);
 });


### PR DESCRIPTION
Fixes #14.

A cold Chrome `AudioContext` can report `running` before its output renderer processes source commands. Cuelume's wall-clock cleanup could then disconnect short recipes before their first block reached the destination.

This change primes the shared output with a 20 ms silent buffer before flushing first-playback cues, schedules recipes 10 ms ahead after graph setup, lets finite noise buffers end naturally, and starts cleanup from actual source completion. Playback after the one-time primer remains immediate.

The original React integration report is https://github.com/shivekkhurana/react-morpheus/issues/5.

Validation:

- `npm test` (7/7)
- `npm pack --dry-run`
- Chrome 152 fresh-process capture: published 0.2.2 `press` 17/20; this branch `press` 20/20 and `tick` 20/20
